### PR TITLE
Add Composer branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,5 +19,10 @@
     },
     "config": {
         "bin-dir": "bin"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0.x-dev"
+        }
     }
 }


### PR DESCRIPTION
`branch-alias` tells Composer which library version the commits in the master branch should be considered to be.

The additions in this commit allows anyone requiring this library in their composer.json to use a version constraint that matches the development version for 1.0. So as long as you intend to keep the master branch compatible with your 1.0 API (once tagged) this branch alias will be fine.

In the event you want to add more features or break the API and increment the library to 1.1, you would then branch off and create a branch named "1.0" where you would maintain backwards compatibility and bug fixes for the 1.0 version. Your master branch would then be considered the development branch for 1.1 and you would update the "branch-alias" to be:

"dev-master": "1.1.x-dev"
