### PR TITLE
Remove classmap from Composer config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,6 @@
         }
     ],
     "autoload": {
-        "classmap": [""],
         "psr-0": {"": "src/"}
     },
     "require": {


### PR DESCRIPTION
As pointed out by @umpirsky in #18 we are not using Composer autoloader's classmap and its presence was causing "Ambiguous class resolution" when running `composer install` after cloning this repo.

After this PR the "Warning: Ambiguous class resolution" lines no longer display when running composer install:

    $ php -v
    PHP 5.6.17 (cli) (built: Jan  8 2016 10:32:22)
    Copyright (c) 1997-2015 The PHP Group
    Zend Engine v2.6.0, Copyright (c) 1998-2015 Zend Technologies
        with Zend OPcache v7.0.6-dev, Copyright (c) 1999-2015, by Zend Technologies
        with Xdebug v2.2.5, Copyright (c) 2002-2014, by Derick Rethans
    
    $ composer --version
    You are running composer with xdebug enabled. This has a major impact on runtime performance. See https://getcomposer.org/xdebug
    Composer version 1.0-dev (93501a5e3f8433e982da3518e13896ee4c0e816b) 2016-02-16 13:33:00
    
    $ composer install
    You are running composer with xdebug enabled. This has a major impact on runtime performance. See https://getcomposer.org/xdebug
    Loading composer repositories with package information
    Installing dependencies (including require-dev) from lock file
      - Installing guzzlehttp/promises (1.0.3)
        Loading from cache

      - Installing psr/http-message (1.0)
        Loading from cache

      - Installing guzzlehttp/psr7 (1.2.2)
        Loading from cache

      - Installing phpunit/php-token-stream (1.2.2)
        Loading from cache

      - Installing symfony/yaml (v2.8.2)
        Loading from cache

      - Installing phpunit/php-text-template (1.2.1)
        Loading from cache

      - Installing phpunit/phpunit-mock-objects (1.2.3)
        Loading from cache

      - Installing phpunit/php-timer (1.0.7)
        Loading from cache

      - Installing phpunit/php-file-iterator (1.4.1)
        Loading from cache

      - Installing phpunit/php-code-coverage (1.2.18)
        Loading from cache

      - Installing phpunit/phpunit (3.7.38)
        Loading from cache

      - Installing symfony/stopwatch (v3.0.2)
        Loading from cache

      - Installing symfony/polyfill-mbstring (v1.1.0)
        Loading from cache

      - Installing symfony/console (v3.0.2)
        Loading from cache

      - Installing symfony/filesystem (v3.0.2)
        Loading from cache

      - Installing symfony/config (v3.0.2)
        Loading from cache

      - Installing psr/log (1.0.0)
        Loading from cache

      - Installing guzzlehttp/guzzle (6.1.1)
        Loading from cache

      - Installing satooshi/php-coveralls (dev-master 50c60bb)
        Cloning 50c60bb64054974f8ed7540ae6e75fd7981a5fd3

    phpunit/phpunit suggests installing phpunit/php-invoker (~1.1)
    symfony/console suggests installing symfony/event-dispatcher ()
    symfony/console suggests installing symfony/process ()
    satooshi/php-coveralls suggests installing symfony/http-kernel (Allows Symfony integration)
    Generating autoload files
    Warning: Ambiguous class resolution, "PHPCS_Sniffs_ControlStructures_ControlSignatureSniff" was found in both "/Users/johnkary/Sites/PHPEncryptData/vendor/phpunit/php-code-coverage/build/PHPCS/Sniffs/ControlStructures/ControlSignatureSniff.php" and "/Users/johnkary/Sites/PHPEncryptData/vendor/phpunit/php-token-stream/build/PHPCS/Sniffs/ControlStructures/ControlSignatureSniff.php", the first will be used.
    Warning: Ambiguous class resolution, "PHPCS_Sniffs_Whitespace_ConcatenationSpacingSniff" was found in both "/Users/johnkary/Sites/PHPEncryptData/vendor/phpunit/php-code-coverage/build/PHPCS/Sniffs/Whitespace/ConcatenationSpacingSniff.php" and "/Users/johnkary/Sites/PHPEncryptData/vendor/phpunit/php-token-stream/build/PHPCS/Sniffs/Whitespace/ConcatenationSpacingSniff.php", the first will be used.
    Warning: Ambiguous class resolution, "PHPCS_Sniffs_ControlStructures_ControlSignatureSniff" was found in both "/Users/johnkary/Sites/PHPEncryptData/vendor/phpunit/php-code-coverage/build/PHPCS/Sniffs/ControlStructures/ControlSignatureSniff.php" and "/Users/johnkary/Sites/PHPEncryptData/vendor/phpunit/phpunit/build/PHPCS/Sniffs/ControlStructures/ControlSignatureSniff.php", the first will be used.
    Warning: Ambiguous class resolution, "PHPCS_Sniffs_Whitespace_ConcatenationSpacingSniff" was found in both "/Users/johnkary/Sites/PHPEncryptData/vendor/phpunit/php-code-coverage/build/PHPCS/Sniffs/Whitespace/ConcatenationSpacingSniff.php" and "/Users/johnkary/Sites/PHPEncryptData/vendor/phpunit/phpunit/build/PHPCS/Sniffs/Whitespace/ConcatenationSpacingSniff.php", the first will be used.
    Warning: Ambiguous class resolution, "PHPCS_Sniffs_ControlStructures_ControlSignatureSniff" was found in both "/Users/johnkary/Sites/PHPEncryptData/vendor/phpunit/php-code-coverage/build/PHPCS/Sniffs/ControlStructures/ControlSignatureSniff.php" and "/Users/johnkary/Sites/PHPEncryptData/vendor/phpunit/phpunit-mock-objects/build/PHPCS/Sniffs/ControlStructures/ControlSignatureSniff.php", the first will be used.
    Warning: Ambiguous class resolution, "PHPCS_Sniffs_Whitespace_ConcatenationSpacingSniff" was found in both "/Users/johnkary/Sites/PHPEncryptData/vendor/phpunit/php-code-coverage/build/PHPCS/Sniffs/Whitespace/ConcatenationSpacingSniff.php" and "/Users/johnkary/Sites/PHPEncryptData/vendor/phpunit/phpunit-mock-objects/build/PHPCS/Sniffs/Whitespace/ConcatenationSpacingSniff.php", the first will be used.