### PR TITLE
Pin satooshi/php-coveralls to PHP 5.3+ compatible version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~3.7",
-        "satooshi/php-coveralls": "dev-master"
+        "satooshi/php-coveralls": "~1.0"
     },
     "config": {
         "bin-dir": "vendor/bin"


### PR DESCRIPTION
As @umpirsky pointed out in #18 relying on satooshi/php-coveralls dev-master was causing Travis CI failures on 5.3 and 5.4 because satooshi/php-coveralls recently bumped PHP version constraint to 5.5+ to accommodate Guzzle 6. Discussion context here: https://github.com/satooshi/php-coveralls/pull/157

This PR pins satooshi/php-coveralls to a version that will remain PHP 5.3+ compatible.