### PR TITLE
Autoload using PSR-4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "autoload": {
-        "psr-0": {"": "src/"}
+        "psr-4": {"PHPEncryptData\\": "src"}
     },
     "require": {
         "ext-mcrypt": "*"


### PR DESCRIPTION
After we removed the Composer classmap in #19 I forgot we still needed a way to autoload classes :frowning:

This PR adds autoloading based on PSR-4 standards: http://www.php-fig.org/psr/psr-4/
tl;dr -- Maps a given namespace to a given source folder, eliminating the need for 1:1 mapping between namespace and directory names. Most popular open-source projects now use this autoloading standard.
